### PR TITLE
Add isInteger and toInteger operations to ContourNumber

### DIFF
--- a/packages/contour/lib/src/instance.dart
+++ b/packages/contour/lib/src/instance.dart
@@ -16,7 +16,9 @@ abstract class VariableInstance<T> extends Listenable<T> {
 
 /// An instance of a variable with a specific type.
 class SingleVariableInstance<T> extends VariableInstance<T> {
-  SingleVariableInstance(super.type, super.name);
+  SingleVariableInstance(super.type, super.name, [dynamic value]) {
+    this.value = value;
+  }
 
   ContourErrors _errors = [];
 

--- a/packages/contour/lib/src/instance.dart
+++ b/packages/contour/lib/src/instance.dart
@@ -16,6 +16,9 @@ abstract class VariableInstance<T> extends Listenable<T> {
 
 /// An instance of a variable with a specific type.
 class SingleVariableInstance<T> extends VariableInstance<T> {
+  /// Creates a new instance with the specified type and name.
+  /// 
+  /// If [value] is provided, it will be set as the initial value of this instance.
   SingleVariableInstance(super.type, super.name, [dynamic value]) {
     this.value = value;
   }

--- a/packages/contour/lib/src/types/boolean.dart
+++ b/packages/contour/lib/src/types/boolean.dart
@@ -80,8 +80,8 @@ class ContourBoolean extends ContourType<bool, ContourBoolean> {
   }
 
   @override
-  SingleVariableInstance<bool> instance(String name) {
-    return SingleVariableInstance<bool>(this, name);
+  SingleVariableInstance<bool> instance(String name, [dynamic value]) {
+    return SingleVariableInstance<bool>(this, name, value);
   }
 }
 

--- a/packages/contour/lib/src/types/list.dart
+++ b/packages/contour/lib/src/types/list.dart
@@ -90,13 +90,15 @@ class ContourList extends ContourType<List, ContourList> {
   ]);
 
   @override
-  VariableInstance<List> instance(String name) {
-    return ListVariableInstance(this, name);
+  VariableInstance<List> instance(String name, [dynamic value]) {
+    return ListVariableInstance(this, name, value);
   }
 }
 
 class ListVariableInstance extends VariableInstance<List> {
-  ListVariableInstance(super.type, super.name);
+  ListVariableInstance(super.type, super.name, value) {
+    this.value = value;
+  }
   ContourErrors _errors = [];
   List? _value;
 

--- a/packages/contour/lib/src/types/number.dart
+++ b/packages/contour/lib/src/types/number.dart
@@ -76,6 +76,25 @@ class ContourNumber extends ContourType<num, ContourNumber> {
     ]);
   }
 
+  // add  check to verify if number is an integer
+  ContourNumber isInteger() {
+    return ContourNumber([
+      ...operations,
+      ContourOperation.check('isInteger', (field, currentValue) {
+        if ((currentValue ?? 0.001) % 1 != 0) {
+          return ContourParseResult<num>(null, [
+            ContourError(
+              field: field,
+              type: ContourErrorType.check,
+              message: 'should be an integer',
+            ),
+          ]);
+        }
+        return ContourParseResult<num>(currentValue, []);
+      }),
+    ]);
+  }
+
   ContourNumber oneOf(List<num> values) {
     return ContourNumber([
       ...operations,
@@ -90,6 +109,16 @@ class ContourNumber extends ContourType<num, ContourNumber> {
           ]);
         }
         return ContourParseResult<num>(currentValue, []);
+      }),
+    ]);
+  }
+
+  // add a transformation to integer
+  ContourNumber toInteger() {
+    return ContourNumber([
+      ...operations,
+      ContourOperation.transform('toInteger', (field, currentValue) {
+        return ContourParseResult<num>(currentValue?.toInt(), []);
       }),
     ]);
   }

--- a/packages/contour/lib/src/types/number.dart
+++ b/packages/contour/lib/src/types/number.dart
@@ -81,7 +81,8 @@ class ContourNumber extends ContourType<num, ContourNumber> {
     return ContourNumber([
       ...operations,
       ContourOperation.check('isInteger', (field, currentValue) {
-        if ((currentValue ?? 0.001) % 1 != 0) {
+-      if ((currentValue ?? 0.001) % 1 != 0) {
++      if (currentValue == null || currentValue % 1 != 0) {
           return ContourParseResult<num>(null, [
             ContourError(
               field: field,

--- a/packages/contour/lib/src/types/number.dart
+++ b/packages/contour/lib/src/types/number.dart
@@ -124,8 +124,8 @@ class ContourNumber extends ContourType<num, ContourNumber> {
   }
 
   @override
-  SingleVariableInstance<num> instance(String name) {
-    return SingleVariableInstance<num>(this, name);
+  VariableInstance<num> instance(String name, [dynamic value]) {
+    return SingleVariableInstance<num>(this, name, value);
   }
 }
 

--- a/packages/contour/lib/src/types/number.dart
+++ b/packages/contour/lib/src/types/number.dart
@@ -77,21 +77,26 @@ class ContourNumber extends ContourType<num, ContourNumber> {
   }
 
   // add  check to verify if number is an integer
-  ContourNumber isInteger() {
+  ContourNumber integer(bool force) {
     return ContourNumber([
       ...operations,
-      ContourOperation.check('isInteger', (field, currentValue) {
-        if ((currentValue ?? 0.001) % 1 != 0) {
-          return ContourParseResult<num>(null, [
-            ContourError(
-              field: field,
-              type: ContourErrorType.check,
-              message: 'should be an integer',
-            ),
-          ]);
-        }
-        return ContourParseResult<num>(currentValue, []);
-      }),
+      if (!force)
+        ContourOperation.check('integer', (field, currentValue) {
+          if ((currentValue ?? 0.001) % 1 != 0) {
+            return ContourParseResult<num>(null, [
+              ContourError(
+                field: field,
+                type: ContourErrorType.check,
+                message: 'should be an integer',
+              ),
+            ]);
+          }
+          return ContourParseResult<num>(currentValue, []);
+        })
+      else
+        ContourOperation.transform('integer', (field, currentValue) {
+          return ContourParseResult<num>(currentValue?.toInt(), []);
+        }),
     ]);
   }
 
@@ -109,16 +114,6 @@ class ContourNumber extends ContourType<num, ContourNumber> {
           ]);
         }
         return ContourParseResult<num>(currentValue, []);
-      }),
-    ]);
-  }
-
-  // add a transformation to integer
-  ContourNumber toInteger() {
-    return ContourNumber([
-      ...operations,
-      ContourOperation.transform('toInteger', (field, currentValue) {
-        return ContourParseResult<num>(currentValue?.toInt(), []);
       }),
     ]);
   }

--- a/packages/contour/lib/src/types/object.dart
+++ b/packages/contour/lib/src/types/object.dart
@@ -1,15 +1,5 @@
-import 'package:contour/src/key.dart' show VariableKey;
+import 'package:contour/contour.dart';
 import 'package:contour/src/types/list.dart' show ListVariableInstance;
-
-import '../instance.dart' show VariableInstance;
-import '../type.dart'
-    show
-        ContourError,
-        ContourErrorType,
-        ContourErrors,
-        ContourOperation,
-        ContourParseResult,
-        ContourType;
 
 class ContourObject extends ContourType<Map<String, dynamic>, ContourObject> {
   final Map<String, ContourType> schema;
@@ -44,6 +34,7 @@ class ContourObject extends ContourType<Map<String, dynamic>, ContourObject> {
 
     final objectResult = super.parse(value, name: name);
     if (objectResult.errors.isNotEmpty) {
+      values.addAll(objectResult.value ?? {});
       errors.addAll(objectResult.errors);
     } else {
       values.addAll(objectResult.value ?? {});
@@ -99,20 +90,35 @@ class ContourObject extends ContourType<Map<String, dynamic>, ContourObject> {
     return ContourObject(schema, [
       ...operations,
       ContourOperation.check('additionalFields', (field, currentValue) {
-        if (!allow && currentValue != null) {
+        if (currentValue != null) {
           final extraFields =
               currentValue.keys
                   .where((key) => !schema.containsKey(key))
                   .toList();
           if (extraFields.isNotEmpty) {
-            return ContourParseResult<Map<String, dynamic>>(null, [
-              ContourError(
-                field: field,
-                type: ContourErrorType.check,
-                message:
-                    'contains additional fields: ${extraFields.join(', ')}',
-              ),
-            ]);
+            if (!allow) {
+              // remove extra fields
+              for (final key in extraFields) {
+                currentValue.remove(key);
+              }
+              return ContourParseResult<Map<String, dynamic>>(null, [
+                ContourError(
+                  field: field,
+                  type: ContourErrorType.check,
+                  message:
+                      'contains additional fields: ${extraFields.join(', ')}',
+                ),
+              ]);
+            } else {
+              return ContourParseResult<Map<String, dynamic>>(currentValue, [
+                ContourError(
+                  field: field,
+                  type: ContourErrorType.check,
+                  message:
+                      'contains additional fields: ${extraFields.join(', ')}',
+                ),
+              ]);
+            }
           }
         }
         return ContourParseResult<Map<String, dynamic>>(currentValue, []);
@@ -137,7 +143,7 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
     : assert(type is ContourObject) {
     for (final field in (type as ContourObject).schema.entries) {
       _instances[field.key] = field.value.instance(field.key);
-      _instances[field.key]!.subscribe((_) => notifySubscribers(value));
+      _instances[field.key]!.subscribe((_) => notifySubscribers(this.value));
     }
     if (value != null) {
       this.value = value;
@@ -159,7 +165,7 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
   }
 
   @override
-  Map<String, dynamic>? get value {
+  Map<String, dynamic> get value {
     final result = <String, dynamic>{};
     for (final entry in _instances.entries) {
       result[entry.key] = entry.value.value;
@@ -173,6 +179,14 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
     _errors = result.errors;
 
     final valueToUse = result.value;
+
+    // First, clear any additional field instances that might have been added previously
+    final schemaKeys = (type as ContourObject).schema.keys.toSet();
+    final keysToRemove =
+        _instances.keys.where((k) => !schemaKeys.contains(k)).toList();
+    for (final key in keysToRemove) {
+      _instances.remove(key);
+    }
 
     if (inputValue == null) {
       if (valueToUse == null) {
@@ -188,15 +202,53 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
         }
       }
     } else {
-      // Normal case - set values from input
+      // Handle schema-defined fields
       for (final entry in _instances.entries) {
-        if (inputValue.containsKey(entry.key)) {
-          entry.value.value = inputValue[entry.key];
+        if (valueToUse?.containsKey(entry.key) ?? false) {
+          entry.value.value = valueToUse![entry.key];
+        }
+      }
+
+      // Check if additional fields are allowed
+      bool hasAdditionalFieldsOp = false;
+      bool allowAdditionalFields = false;
+
+      for (final op in (type as ContourObject).operations) {
+        if (op.name == 'additionalFields') {
+          hasAdditionalFieldsOp = true;
+          // If the operation is present and the additional fields still exist in valueToUse,
+          // then they are allowed
+          if (valueToUse != null) {
+            final additionalKeys =
+                valueToUse.keys
+                    .where((key) => !schemaKeys.contains(key))
+                    .toList();
+            allowAdditionalFields = additionalKeys.isNotEmpty;
+          }
+          break;
+        }
+      }
+
+      // Handle additional fields if they're allowed
+      if (hasAdditionalFieldsOp &&
+          allowAdditionalFields &&
+          valueToUse != null) {
+        for (final key in valueToUse.keys) {
+          if (!schemaKeys.contains(key)) {
+            // Create a basic instance for this additional field
+            final value = valueToUse[key];
+
+            // Use a ContourString instance as a generic holder
+            // This is a simple approach - in a real implementation, you might want to
+            // detect the type and use the appropriate ContourType
+            _instances[key] = ContourString().instance(key, value);
+            _instances[key]!.subscribe((_) => notifySubscribers(this.value));
+          }
         }
       }
     }
 
-    notifySubscribers(valueToUse);
+    notifySubscribers(value);
   }
 
   @override
@@ -214,7 +266,7 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
   @override
   bool get valid => errors.isEmpty;
 
-  /// Modified operator [] to return the instance for compound types.
+  /// Returns the instance for compound types or the value for primitive types
   dynamic operator [](String key) {
     final instance = _instances[key];
     if (instance == null) return null;
@@ -227,7 +279,11 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
 
   void operator []=(String key, dynamic value) {
     final instance = _instances[key];
-    if (instance == null) return;
+    if (instance == null) {
+      // For non-schema fields, we don't add them dynamically via bracket notation
+      // They should only be added through the value setter
+      return;
+    }
     instance.value = value;
   }
 

--- a/packages/contour/lib/src/types/object.dart
+++ b/packages/contour/lib/src/types/object.dart
@@ -121,8 +121,8 @@ class ContourObject extends ContourType<Map<String, dynamic>, ContourObject> {
   }
 
   @override
-  ObjectVariableInstance instance(String name) {
-    return ObjectVariableInstance(this, name);
+  ObjectVariableInstance instance(String name, [dynamic value]) {
+    return ObjectVariableInstance(this, name, value);
   }
 }
 
@@ -133,11 +133,14 @@ class ObjectVariableInstance extends VariableInstance<Map<String, dynamic>> {
   final Map<String, VariableInstance> _instances = {};
   ContourErrors _errors = [];
 
-  ObjectVariableInstance(super.type, super.name)
+  ObjectVariableInstance(super.type, super.name, [dynamic value])
     : assert(type is ContourObject) {
     for (final field in (type as ContourObject).schema.entries) {
       _instances[field.key] = field.value.instance(field.key);
       _instances[field.key]!.subscribe((_) => notifySubscribers(value));
+    }
+    if (value != null) {
+      this.value = value;
     }
   }
 

--- a/packages/contour/lib/src/types/string.dart
+++ b/packages/contour/lib/src/types/string.dart
@@ -92,8 +92,8 @@ class ContourString extends ContourType<String, ContourString> {
   }
 
   @override
-  SingleVariableInstance<String> instance(String name) {
-    return SingleVariableInstance<String>(this, name);
+  SingleVariableInstance<String> instance(String name, [dynamic value]) {
+    return SingleVariableInstance<String>(this, name, value);
   }
 }
 

--- a/packages/contour/test/src/types/boolean_test.dart
+++ b/packages/contour/test/src/types/boolean_test.dart
@@ -88,4 +88,16 @@ void main() {
       expect(instance.value, false);
     });
   });
+
+  test('initial value should be null', () {
+    final numberType = ContourBoolean();
+    final instance = numberType.instance('test');
+    expect(instance.value, isNull);
+  });
+
+  test('initial value should be set', () {
+    final numberType = ContourBoolean();
+    final instance = numberType.instance('test', true);
+    expect(instance.value, true);
+  });
 }

--- a/packages/contour/test/src/types/boolean_test.dart
+++ b/packages/contour/test/src/types/boolean_test.dart
@@ -90,14 +90,14 @@ void main() {
   });
 
   test('initial value should be null', () {
-    final numberType = ContourBoolean();
-    final instance = numberType.instance('test');
+    final booleanType = ContourBoolean();
+    final instance = booleanType.instance('test');
     expect(instance.value, isNull);
   });
 
   test('initial value should be set', () {
-    final numberType = ContourBoolean();
-    final instance = numberType.instance('test', true);
+    final booleanType = ContourBoolean();
+    final instance = booleanType.instance('test', true);
     expect(instance.value, true);
   });
 }

--- a/packages/contour/test/src/types/list_test.dart
+++ b/packages/contour/test/src/types/list_test.dart
@@ -104,5 +104,16 @@ void main() {
       },
     );
     // Check your expected behavior based on implementation
+    test('initial value should be null', () {
+      final objectType = ContourList(ContourNumber());
+      final instance = objectType.instance('test');
+      expect(instance.value, null);
+    });
+
+    test('initial value should be set', () {
+      final objectType = ContourList(ContourNumber());
+      final instance = objectType.instance('test', [1, 2, 3]);
+      expect(instance.value, [1, 2, 3]);
+    });
   });
 }

--- a/packages/contour/test/src/types/number_test.dart
+++ b/packages/contour/test/src/types/number_test.dart
@@ -130,14 +130,14 @@ void main() {
       expect(instance.errors.isEmpty, isTrue);
     });
 
-    test('isInteger should add a isInteger operation', () {
-      final numberType = ContourNumber().isInteger();
-      final result = numberType.operations.any((op) => op.name == 'isInteger');
+    test('integer should add a isInteger operation', () {
+      final numberType = ContourNumber().integer(false);
+      final result = numberType.operations.any((op) => op.name == 'integer');
       expect(result, isTrue);
     });
 
-    test('isInteger should validate number value', () {
-      final numberType = ContourNumber().isInteger();
+    test('integer(false) should validate number value', () {
+      final numberType = ContourNumber().integer(false);
       final instance = numberType.instance('test');
 
       instance.value = 1.1;
@@ -147,34 +147,28 @@ void main() {
       instance.value = 1;
       expect(instance.errors.isEmpty, isTrue);
     });
-  });
 
-  test('toInteger should add a toInteger operation', () {
-    final numberType = ContourNumber().toInteger();
-    final result = numberType.operations.any((op) => op.name == 'toInteger');
-    expect(result, isTrue);
-  });
+    test('integer(true) should transform to an integer', () {
+      final numberType = ContourNumber().integer(true);
+      final instance = numberType.instance('test');
 
-  test('toInteger should validate number value', () {
-    final numberType = ContourNumber().toInteger();
-    final instance = numberType.instance('test');
+      instance.value = 1.1;
+      expect(instance.value, 1);
 
-    instance.value = 1.1;
-    expect(instance.value, 1);
+      instance.value = 1;
+      expect(instance.value, 1);
+    });
 
-    instance.value = 1;
-    expect(instance.value, 1);
-  });
+    test('initial value should be null', () {
+      final numberType = ContourNumber();
+      final instance = numberType.instance('test');
+      expect(instance.value, isNull);
+    });
 
-  test('initial value should be null', () {
-    final numberType = ContourNumber();
-    final instance = numberType.instance('test');
-    expect(instance.value, isNull);
-  });
-
-  test('initial value should be set', () {
-    final numberType = ContourNumber();
-    final instance = numberType.instance('test', 123);
-    expect(instance.value, 123);
+    test('initial value should be set', () {
+      final numberType = ContourNumber();
+      final instance = numberType.instance('test', 123);
+      expect(instance.value, 123);
+    });
   });
 }

--- a/packages/contour/test/src/types/number_test.dart
+++ b/packages/contour/test/src/types/number_test.dart
@@ -165,4 +165,16 @@ void main() {
     instance.value = 1;
     expect(instance.value, 1);
   });
+
+  test('initial value should be null', () {
+    final numberType = ContourNumber();
+    final instance = numberType.instance('test');
+    expect(instance.value, isNull);
+  });
+
+  test('initial value should be set', () {
+    final numberType = ContourNumber();
+    final instance = numberType.instance('test', 123);
+    expect(instance.value, 123);
+  });
 }

--- a/packages/contour/test/src/types/number_test.dart
+++ b/packages/contour/test/src/types/number_test.dart
@@ -129,5 +129,40 @@ void main() {
       instance.value = 1;
       expect(instance.errors.isEmpty, isTrue);
     });
+
+    test('isInteger should add a isInteger operation', () {
+      final numberType = ContourNumber().isInteger();
+      final result = numberType.operations.any((op) => op.name == 'isInteger');
+      expect(result, isTrue);
+    });
+
+    test('isInteger should validate number value', () {
+      final numberType = ContourNumber().isInteger();
+      final instance = numberType.instance('test');
+
+      instance.value = 1.1;
+      expect(instance.errors.isNotEmpty, isTrue);
+      expect(instance.errors.first.message, 'should be an integer');
+
+      instance.value = 1;
+      expect(instance.errors.isEmpty, isTrue);
+    });
+  });
+
+  test('toInt should add a toInteger operation', () {
+    final numberType = ContourNumber().toInteger();
+    final result = numberType.operations.any((op) => op.name == 'toInteger');
+    expect(result, isTrue);
+  });
+
+  test('toInt should validate number value', () {
+    final numberType = ContourNumber().toInteger();
+    final instance = numberType.instance('test');
+
+    instance.value = 1.1;
+    expect(instance.value, 1);
+
+    instance.value = 1;
+    expect(instance.value, 1);
   });
 }

--- a/packages/contour/test/src/types/number_test.dart
+++ b/packages/contour/test/src/types/number_test.dart
@@ -149,13 +149,13 @@ void main() {
     });
   });
 
-  test('toInt should add a toInteger operation', () {
+  test('toInteger should add a toInteger operation', () {
     final numberType = ContourNumber().toInteger();
     final result = numberType.operations.any((op) => op.name == 'toInteger');
     expect(result, isTrue);
   });
 
-  test('toInt should validate number value', () {
+  test('toInteger should validate number value', () {
     final numberType = ContourNumber().toInteger();
     final instance = numberType.instance('test');
 

--- a/packages/contour/test/src/types/object_test.dart
+++ b/packages/contour/test/src/types/object_test.dart
@@ -34,13 +34,17 @@ void main() {
       expect(result.value, {'name': 'John', 'age': 30});
     });
 
-    test('parse should return empty fields for non-map fields ', () {
+    test('parse should not return non-mappable fields', () {
       final objectType = ContourObject({
         'name': ContourString(),
         'age': ContourNumber(),
       }).additionalFields(false);
-      final result = objectType.parse({'bla': 'not a map'});
-      expect(result.value, {'name': null, 'age': null});
+      final result = objectType.parse({
+        'name': 'John',
+        'age': 30,
+        'bla': 'not a map',
+      });
+      expect(result.value, {'name': 'John', 'age': 30});
       expect(result.errors, isNotEmpty);
       expect(result.errors.first.message, 'contains additional fields: bla');
     });
@@ -263,6 +267,39 @@ void main() {
       expect(instance.value, {
         'name': {'first': 'John', 'last': 'Doe'},
         'age': null,
+      });
+    });
+
+    test('initial value should be null', () {
+      final objectType = ContourObject({
+        'name': ContourObject({
+          'first': ContourString(),
+          'last': ContourString(),
+        }),
+        'age': ContourNumber(),
+      });
+      final instance = objectType.instance('test');
+      expect(instance.value, {
+        'name': {'first': null, 'last': null},
+        'age': null,
+      });
+    });
+
+    test('initial value should be set', () {
+      final objectType = ContourObject({
+        'name': ContourObject({
+          'first': ContourString(),
+          'last': ContourString(),
+        }),
+        'age': ContourNumber(),
+      });
+      final instance = objectType.instance('test', {
+        'name': {'first': 'John', 'last': 'Doe'},
+        'age': 30,
+      });
+      expect(instance.value, {
+        'name': {'first': 'John', 'last': 'Doe'},
+        'age': 30,
       });
     });
   });

--- a/packages/contour/test/src/types/object_test.dart
+++ b/packages/contour/test/src/types/object_test.dart
@@ -56,7 +56,7 @@ void main() {
       }).additionalFields(true);
       final result = objectType.parse({'bla': 'not a map'});
       expect(result.value, {'name': null, 'age': null, 'bla': 'not a map'});
-      expect(result.errors, isEmpty);
+      expect(result.errors, isNotEmpty);
     });
 
     test('optional should remove required operation', () {
@@ -136,7 +136,28 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('additionalFields should validate map value', () {
+    test('should validate additionalFields and allow', () {
+      final objectType = ContourObject({
+        'name': ContourString(),
+        'age': ContourNumber(),
+      }).additionalFields(true);
+      final instance = objectType.instance('test');
+      instance.value = {'name': 'John', 'age': 30};
+      expect(instance.errors.isEmpty, isTrue);
+      instance.value = {
+        'name': 'John',
+        'age': 30,
+        'extra': 'field',
+      }; // extra field
+      expect(instance.errors.isNotEmpty, isTrue);
+      expect(
+        instance.errors.first.message,
+        'contains additional fields: extra',
+      );
+      expect(instance.value, {'name': 'John', 'age': 30, 'extra': 'field'});
+    });
+
+    test('shoudl validate additionalFields and remove', () {
       final objectType = ContourObject({
         'name': ContourString(),
         'age': ContourNumber(),
@@ -154,6 +175,7 @@ void main() {
         instance.errors.first.message,
         'contains additional fields: extra',
       );
+      expect(instance.value, {'name': 'John', 'age': 30});
     });
 
     test('should access value using bracket notation', () {

--- a/packages/contour/test/src/types/string_test.dart
+++ b/packages/contour/test/src/types/string_test.dart
@@ -100,14 +100,14 @@ void main() {
   });
 
   test('initial value should be null', () {
-    final numberType = ContourString();
-    final instance = numberType.instance('test');
+    final stringType = ContourString();
+    final instance = stringType.instance('test');
     expect(instance.value, isNull);
   });
 
   test('initial value should be set', () {
-    final numberType = ContourString();
-    final instance = numberType.instance('test', 'value');
+    final stringType = ContourString();
+    final instance = stringType.instance('test', 'value');
     expect(instance.value, 'value');
   });
 }

--- a/packages/contour/test/src/types/string_test.dart
+++ b/packages/contour/test/src/types/string_test.dart
@@ -98,4 +98,16 @@ void main() {
       expect(instance.errors.isEmpty, isTrue);
     });
   });
+
+  test('initial value should be null', () {
+    final numberType = ContourString();
+    final instance = numberType.instance('test');
+    expect(instance.value, isNull);
+  });
+
+  test('initial value should be set', () {
+    final numberType = ContourString();
+    final instance = numberType.instance('test', 'value');
+    expect(instance.value, 'value');
+  });
 }


### PR DESCRIPTION
Add isInteger and toInteger operations to ContourNumber for validation and transformation

number.dart
isInteger and to Integer added

number_test.dart
4 additional tests
- isInteger should add a isInteger operation
- isInteger should validate number value
- toInteger should add a toInteger operation
- toInteger should validate number value

Fixes #58 and #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced initialization: Users can now supply an optional initial value when creating instances for common data types (booleans, lists, numbers, objects, and strings).
  - Improved numeric support: New operations allow for integer validation and conversion to ensure numeric values are processed accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->